### PR TITLE
Update SetInteriorVehicleDataRequestTests

### DIFF
--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/test/commands/set_interior_vehicle_data_request_test.cc
@@ -165,7 +165,7 @@ TEST_F(SetInteriorVehicleDataRequestTest,
       (*mobile_message)[application_manager::strings::msg_params];
   msg_params[kModuleData][kModuleType] = mobile_apis::ModuleType::CLIMATE;
   auto& control_data = msg_params[kModuleData][kClimateControlData];
-  const uint64_t fan_speed = 10;
+  const uint64_t fan_speed = 10u;
   control_data[kFanSpeed] = fan_speed;
 
   // Expectations
@@ -183,7 +183,7 @@ TEST_F(SetInteriorVehicleDataRequestTest,
   command->Run();
 
   EXPECT_TRUE(control_data.keyExists(kFanSpeed) &&
-              fan_speed == control_data[kFanSpeed].asUInt());
+              control_data[kFanSpeed].asUInt() == fan_speed);
 }
 
 TEST_F(
@@ -198,7 +198,7 @@ TEST_F(
   msg_params[kModuleData][kModuleType] = mobile_apis::ModuleType::RADIO;
   auto& control_data = msg_params[kModuleData][kRadioControlData];
   control_data[kState] = true;
-  const auto radio_enable = true;
+  const bool radio_enable = true;
   control_data[kRadioEnable] = radio_enable;
 
   ON_CALL(mock_rc_capabilities_manager_, ControlDataForType(_, _))
@@ -223,7 +223,7 @@ TEST_F(
 
   EXPECT_FALSE(control_data.keyExists(kState));
   EXPECT_TRUE(control_data.keyExists(kRadioEnable) &&
-              radio_enable == control_data[kRadioEnable].asBool());
+              control_data[kRadioEnable].asBool() == radio_enable);
 }
 
 TEST_F(


### PR DESCRIPTION
This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
The PR adds a check whether read only parameters are cut off before sending a message to
HMI in unit tests for SetInteriorVehicleDataRequest.

### Tasks Remaining:
- [ ] Add test cases for all RC modules
- [ ] Add test cases for all flows

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
